### PR TITLE
Enable travis on common versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 
 go:
+  - 1.6.3
+  - 1.7.3
+  - tip
   - master
 
 install:


### PR DESCRIPTION
Enable travis on golang 1.6, 1.7 and tip as well as master.