### PR TITLE
Add slackit sample binary

### DIFF
--- a/cmd/slackit/main.go
+++ b/cmd/slackit/main.go
@@ -1,0 +1,64 @@
+// slackit is a command line golang slack client.
+//
+// It reads a JSON formatted message from the file specified by -src <file>
+// and posts it to slack using the webhook url specified by -hook <url>.
+//
+// By default slackit reads the message from stdin.
+//
+// Example:
+//  slackit -hook https://hooks.slack.com/services/T00/B00/XXX -src msg.json
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/multiplay/go-slack/chat"
+	"github.com/multiplay/go-slack/webhook"
+)
+
+// exit is the function used to exit on error its a variable so it can be easily overridden for tests.
+var exit = os.Exit
+
+func main() {
+	var src = flag.String("src", "-", "reads the message from the specified file or stdin if '-'")
+	var hook = flag.String("hook", "", "the hook url to use")
+
+	flag.Usage = func() {
+		log.Printf("usage %s -hook <url> [-src <file>]\nflags:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+	if *hook == "" {
+		flag.Usage()
+		exit(1)
+	}
+
+	var f *os.File
+
+	if *src == "-" {
+		f = os.Stdin
+	} else {
+		var err error
+		if f, err = os.Open(*src); err != nil {
+			log.Println("failed to open source: ", err)
+			exit(1)
+		}
+	}
+
+	dec := json.NewDecoder(f)
+	m := &chat.Message{}
+	if err := dec.Decode(m); err != nil {
+		log.Println("failed to decode message: ", err)
+		exit(1)
+	}
+
+	c := webhook.New(*hook)
+	if _, err := m.Send(c); err != nil {
+		log.Println("failed to send message:", err)
+		exit(1)
+	}
+}

--- a/cmd/slackit/main_test.go
+++ b/cmd/slackit/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/multiplay/go-slack/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func testSlackit(t *testing.T, hook, msg string) ([]byte, error) {
+	args := make([]string, 0, 2)
+	if hook != "" {
+		args = append(args, "-hook", hook)
+	}
+
+	switch {
+	case msg == "invalid-file":
+		args = append(args, "-src", "invalid-file")
+	case msg != "":
+		tmpfile, err := ioutil.TempFile("", "slackit-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer os.Remove(tmpfile.Name())
+
+		if _, err := tmpfile.Write([]byte(msg)); err != nil {
+			t.Fatal(err)
+		}
+		if err := tmpfile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		args = append(args, "-src", tmpfile.Name())
+	}
+
+	var buf bytes.Buffer
+	var err error
+
+	exit = func(code int) {
+		if code != 0 {
+			err = fmt.Errorf("exit(%v)", code)
+		}
+	}
+	os.Args = append([]string{"slackit"}, args...)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	flag.CommandLine.SetOutput(&buf)
+	log.SetOutput(&buf)
+	main()
+
+	return buf.Bytes(), err
+}
+
+func TestNoArgs(t *testing.T) {
+	b, err := testSlackit(t, "", "")
+	assert.Error(t, err)
+	assert.Contains(t, string(b), "usage")
+}
+
+func TestMissingHook(t *testing.T) {
+	b, err := testSlackit(t, "", "-")
+	assert.Error(t, err)
+	assert.Contains(t, string(b), "usage")
+}
+
+func TestInvalidMessage(t *testing.T) {
+	b, err := testSlackit(t, test.Endpoint, "broken")
+	assert.Error(t, err)
+	assert.Contains(t, string(b), "failed to decode message")
+}
+
+func TestInvalidFile(t *testing.T) {
+	b, err := testSlackit(t, test.Endpoint, "invalid-file")
+	assert.Error(t, err)
+	assert.Contains(t, string(b), "failed to decode message")
+}
+
+func TestSuccess(t *testing.T) {
+	b, err := testSlackit(t, test.Endpoint, `{"text":"my message"}`)
+	assert.NoError(t, err)
+	assert.Empty(t, b)
+}


### PR DESCRIPTION
Added slackit which is a simple binary that reads a message from a file and sends it to slack using the provided webhook URL.