### PR TITLE
Updated references to github.com/Sirupsen/logrus to use lowercase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 install:
   - go get golang.org/x/net/context
   - go get golang.org/x/time/rate
-  - go get github.com/Sirupsen/logrus
+  - go get github.com/sirupsen/logrus
   - go get github.com/stretchr/testify/assert
 
 script: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Features
 * [Slack Webhook](https://api.slack.com/incoming-webhooks) Support.
 * [Slack chat.postMessage](https://api.slack.com/methods/chat.postMessage) Support.
 * Client Interface - Use alternative implementations - currently webhook is the only client.
-* [Logurs Hook](https://github.com/Sirupsen/logrus) Support - Automatically send messages to [Slack](https://slack.com) when using a [Logrus](https://github.com/Sirupsen/logrus) logger.
+* [Logurs Hook](https://github.com/sirupsen/logrus) Support - Automatically send messages to [Slack](https://slack.com) when using a [Logrus](https://github.com/sirupsen/logrus) logger.
 
 Installation
 ------------
@@ -34,13 +34,13 @@ func main() {
 }
 ```
 
-If your using [logrus](https://github.com/Sirupsen/logrus) you can use the webhook to post to slack based on your logging e.g.
+If your using [logrus](https://github.com/sirupsen/logrus) you can use the webhook to post to slack based on your logging e.g.
 ```go
 package main
 
 import (
 	"github.com/multiplay/go-slack/lrhook"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {

--- a/lrhook/hook.go
+++ b/lrhook/hook.go
@@ -3,7 +3,7 @@
 // It can post messages to slack based on the notification level of the
 // logrus entry including the ability to rate limit messages.
 //
-// See: https://godoc.org/github.com/Sirupsen/logrus#Hook
+// See: https://godoc.org/github.com/sirupsen/logrus#Hook
 package lrhook
 
 import (
@@ -13,7 +13,7 @@ import (
 	"github.com/multiplay/go-slack/chat"
 	"github.com/multiplay/go-slack/webhook"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
 

--- a/lrhook/hook_test.go
+++ b/lrhook/hook_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/multiplay/go-slack/chat"
 	"github.com/multiplay/go-slack/test"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
To avoid naming conflicts, logrus recommends converging to lowercase conventions.
[Comment by sirupsen](https://github.com/bshuster-repo/logrus-logstash-hook/issues/32#issuecomment-303195028)
[Issue on logrus](https://github.com/sirupsen/logrus/issues/451)