### PR TITLE
Change mainline version to golang 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.6.3
-  - 1.7.3
+  - 1.9.x
   - tip
   - master
 


### PR DESCRIPTION
Update mainline version of golang for travis tests from 1.7 to 1.9.