### PR TITLE
Remove tip from travis builds and test on latest 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.9.x
-  - tip
+  - 1.x
   - master
 
 install:


### PR DESCRIPTION
Remove tip from the travis builds as its now the same as master and set to test on the latest 1.x version.